### PR TITLE
Refactor Text Did Change Delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+* [#31](https://github.com/Blackjacx/SHSearchBar/pull/31): Refactor Text Did Change Delegation - [@blackjacx](https://github.com/blackjacx).
+
 ### Fixed
 * [#29](https://github.com/Blackjacx/SHSearchBar/pull/29): Italian localization - [@CeceXX](https://github.com/CeceXX).
 

--- a/Source/SHSearchBar.swift
+++ b/Source/SHSearchBar.swift
@@ -108,6 +108,7 @@ public class SHSearchBar: UIView, SHSearchBarDelegate {
         textField.spellCheckingType = .no
         textField.adjustsFontSizeToFitWidth = false
         textField.clipsToBounds = true
+        textField.addTarget(self, action: #selector(didChangeTextField(_:)), for: .editingChanged)
     }
 
     func setupCancelButton(withConfig config: SHSearchBarConfig) {
@@ -116,7 +117,7 @@ public class SHSearchBar: UIView, SHSearchBarDelegate {
         cancelButton.setContentHuggingPriority(.required, for: .horizontal)
         cancelButton.reversesTitleShadowWhenHighlighted = true
         cancelButton.adjustsImageWhenHighlighted = true
-        cancelButton.addTarget(self, action: #selector(SHSearchBar.pressedCancelButton(_:)), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(pressedCancelButton(_:)), for: .touchUpInside)
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -286,6 +287,14 @@ public class SHSearchBar: UIView, SHSearchBarDelegate {
             self.cancelButton.alpha = show ? 1 : 0
         }, completion: nil)
     }
+
+    // MARK: - Handle Text Changes
+
+    @objc func didChangeTextField(_ textField: UITextField) {
+
+        let newText = textField.text ?? ""
+        delegate?.searchBar(self, textDidChange: newText)
+    }
 }
 
 // MARK: - UITextFieldDelegate
@@ -319,13 +328,6 @@ extension SHSearchBar: UITextFieldDelegate {
 
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let shouldChange = delegate?.searchBar(self, shouldChangeCharactersIn: range, replacementString: string) ?? searchBar(self, shouldChangeCharactersIn: range, replacementString: string)
-        if shouldChange {
-            let currentText = NSString(string: textField.text ?? "")
-            let newText: String = currentText.replacingCharacters(in: range, with: string)
-            if !currentText.isEqual(to: newText) {
-                delegate?.searchBar(self, textDidChange: newText)
-            }
-        }
         return shouldChange
     }
 

--- a/Tests/SHSearchBarSpec.swift
+++ b/Tests/SHSearchBarSpec.swift
@@ -272,16 +272,15 @@ class SHSearchBarSpec: QuickSpec {
                     expect(result) == true
                 }
                 it("calls the textDidChange method when text changes") {
-                    let replacement = (searchbar.textField.text ?? "") + " appended text"
-                    expect(alwaysTrueDelegate.hasTextDidChangeBeenCalled).to(beFalse())
-                    _ = searchbar.textField(searchbar.textField, shouldChangeCharactersIn: NSMakeRange(0, 0), replacementString: replacement)
-                    expect(alwaysTrueDelegate.hasTextDidChangeBeenCalled).to(beTrue())
+                    expect(alwaysTrueDelegate.hasTextDidChangeBeenCalled) == false
+                    searchbar.didChangeTextField(UITextField())
+                    expect(alwaysTrueDelegate.hasTextDidChangeBeenCalled) == true
                 }
                 it("does NOT call the textDidChange method when new text is set programmatically") {
                     let newText = (searchbar.textField.text ?? "") + " appended text"
-                    expect(alwaysTrueDelegate.hasTextDidChangeBeenCalled).to(beFalse())
+                    expect(alwaysTrueDelegate.hasTextDidChangeBeenCalled) == false
                     searchbar.textField.text = newText
-                    expect(alwaysTrueDelegate.hasTextDidChangeBeenCalled).to(beFalse())
+                    expect(alwaysTrueDelegate.hasTextDidChangeBeenCalled) == false
                 }
                 it("does NOT call the textDidChange method when text actually not changes") {
                     expect(alwaysTrueDelegate.hasTextDidChangeBeenCalled).to(beFalse())


### PR DESCRIPTION
### Changed

The SHSearchBar now uses target/action to delegate text changes instead of the method UITextField delegate method `shouldChangeText`. `shouldChangeText`has been reduced to return the result of the related delegate method of SHSearchBar. 
**The check if the new text is the current text has been removed and must be moved to the app that uses SHSearchBar**