### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets: [SHSearchBar]
+      platform: ios


### PR DESCRIPTION
Specify `ios` as the documentation platform since package doesn't support macOS where the docs are built by default.

This will fix documentation hosting on the [Swift Package Index](https://swiftpackageindex.com/Blackjacx/SHSearchBar)